### PR TITLE
Update predicate.java

### DIFF
--- a/part-1/03-functional-jdk/jshell/predicate.java
+++ b/part-1/03-functional-jdk/jshell/predicate.java
@@ -5,4 +5,4 @@
 
 Predicate<Integer> over9000 = $ -> $ > 9_000;
 
-Integer result = over9000.test(1_234);
+Boolean result = over9000.test(1_234);


### PR DESCRIPTION
Error while executing the jshell. incompatible types: boolean cannot be converted to java.lang.Integer